### PR TITLE
Test New LLMs (Llama2, CodeLlama, etc.) on Chat-UI?

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,10 +1,10 @@
 ## Privacy
 
-> Last updated: May 15, 2023
+> Last updated: July 23, 2023
 
-Starting with `v0.2` of HuggingChat, users are authenticated through their HF user account.
+Users of HuggingChat are authenticated through their HF user account.
 
-By default, your conversations are shared with the model's authors (for the `v0.2` model, to <a target="_blank" href="https://open-assistant.io/dashboard">Open Assistant</a>) to improve their training data and model over time. Model authors are the custodians of the data collected by their model, even if it's hosted on our platform.
+By default, your conversations may be shared with the respective models' authors (e.g. if you're chatting with the Open Assistant model, to <a target="_blank" href="https://open-assistant.io/dashboard">Open Assistant</a>) to improve their training data and model over time. Model authors are the custodians of the data collected by their model, even if it's hosted on our platform.
 
 If you disable data sharing in your settings, your conversations will not be used for any downstream usage (including for research or model training purposes), and they will only be stored to let you access past conversations. You can click on the Delete icon to delete any past conversation at any moment.
 
@@ -14,9 +14,9 @@ If you disable data sharing in your settings, your conversations will not be use
 
 The goal of this app is to showcase that it is now (May 2023) possible to build an open source alternative to ChatGPT. 💪
 
-For now, it's running OpenAssistant's [latest LLaMA based model](https://huggingface.co/OpenAssistant/oasst-sft-6-llama-30b-xor) (which is one of the current best open source chat models), but the plan in the longer-term is to expose all good-quality chat models from the Hub.
+For now, it's running both OpenAssistant's [latest LLaMA based model](https://huggingface.co/OpenAssistant/oasst-sft-6-llama-30b-xor) (which is one of the current best open source chat models) as well as [Meta's newer Llama 2](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf), but the plan in the longer-term is to expose all good-quality chat models from the Hub.
 
-We are not affiliated with Open Assistant, but if you want to contribute to the training data for the next generation of open models, please consider contributing to https://open-assistant.io/ ❤️
+We are not affiliated with Open Assistant nor Meta AI, but if you want to contribute to the training data for the next generation of open models, please consider contributing to https://open-assistant.io/ or https://ai.meta.com/llama/ ❤️
 
 ## Technical details
 
@@ -26,7 +26,7 @@ This app is running in a [Space](https://huggingface.co/docs/hub/spaces-overview
 
 The inference backend is running the optimized [text-generation-inference](https://github.com/huggingface/text-generation-inference) on HuggingFace's Inference API infrastructure.
 
-It is therefore possible to deploy a copy of this app to a Space and customize it (swap model, add some UI elements, or store user messages according to your own Terms and conditions)
+It is therefore possible to deploy a copy of this app to a Space and customize it (swap model, add some UI elements, or store user messages according to your own Terms and conditions). You can also 1-click deploy your own instance using the [Chat UI Spaces Docker template](https://huggingface.co/new-space?template=huggingchat/chat-ui-template).
 
 We welcome any feedback on this app: please participate to the public discussion at https://huggingface.co/spaces/huggingchat/chat-ui/discussions
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Test New LLMs (CodeLlama, Llama2, etc.) 
+
+Notice you forked chat-ui. if you're trying to test other LLMs (codellama, wizardcoder, etc.) with it, I just wrote a [1-click proxy](https://github.com/BerriAI/litellm#openai-proxy-server) to translate openai calls to huggingface, anthropic, togetherai, etc. api calls.
+
+**code**
+```
+$ pip install litellm
+$ litellm --model huggingface/bigcode/starcoder
+#INFO:     Uvicorn running on http://0.0.0.0:8000
+$ aider --openai-api-base http://0.0.0.0:8000
+```
+
+I'd love to know if this solves a problem for you
+
 ---
 title: chat-ui
 emoji: 🔥

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ MODELS=`[
     "datasetName": "OpenAssistant/oasst1",
     "description": "A good alternative to ChatGPT",
     "websiteUrl": "https://open-assistant.io",
-    "userMessageToken": "<|prompter|>",
-    "assistantMessageToken": "<|assistant|>",
-    "messageEndToken": "</s>",
+    "userMessageToken": "<|prompter|>", # This does not need to be a token, can be any string
+    "assistantMessageToken": "<|assistant|>", # This does not need to be a token, can be any string
+    "messageEndToken": "<|endoftext|>", # This does not need to be a token, can be any string
     "preprompt": "Below are a series of dialogues between various people and an AI assistant. The AI tries to be helpful, polite, honest, sophisticated, emotionally aware, and humble-but-knowledgeable. The assistant is happy to help with almost anything, and will do its best to understand exactly what is needed. It also tries to avoid giving false or misleading information, and it caveats when it isn't entirely sure about the right answer. That said, the assistant is practical and really does its best, and doesn't let caution get too much in the way of being useful.\n-----\n",
     "promptExamples": [
       {
@@ -140,7 +140,8 @@ MODELS=`[
       "repetition_penalty": 1.2,
       "top_k": 50,
       "truncate": 1000,
-      "max_new_tokens": 1024
+      "max_new_tokens": 1024,
+      "stop": ["<|endoftext|>"]  # This does not need to be tokens, can be any list of strings
     }
   }
 ]`

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ MODELS=`[
     "userMessageToken": "<|prompter|>", # This does not need to be a token, can be any string
     "assistantMessageToken": "<|assistant|>", # This does not need to be a token, can be any string
     "messageEndToken": "<|endoftext|>", # This does not need to be a token, can be any string
+    # "userMessageEndToken": "", # Applies only to user messages, messageEndToken has no effect if specified. Can be any string.
+    # "assistantMessageEndToken": "", # Applies only to assistant messages, messageEndToken has no effect if specified. Can be any string.
     "preprompt": "Below are a series of dialogues between various people and an AI assistant. The AI tries to be helpful, polite, honest, sophisticated, emotionally aware, and humble-but-knowledgeable. The assistant is happy to help with almost anything, and will do its best to understand exactly what is needed. It also tries to avoid giving false or misleading information, and it caveats when it isn't entirely sure about the right answer. That said, the assistant is practical and really does its best, and doesn't let caution get too much in the way of being useful.\n-----\n",
     "promptExamples": [
       {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ app_port: 3000
 
 ![Chat UI repository thumbnail](https://huggingface.co/datasets/huggingface/documentation-images/raw/f038917dd40d711a72d654ab1abfc03ae9f177e6/chat-ui-repo-thumbnail.svg)
 
-A chat interface using open source models, eg OpenAssistant. It is a SvelteKit app and it powers the [HuggingChat app on hf.co/chat](https://huggingface.co/chat).
+A chat interface using open source models, eg OpenAssistant or Llama. It is a SvelteKit app and it powers the [HuggingChat app on hf.co/chat](https://huggingface.co/chat).
 
 0. [No Setup Deploy](#no-setup-deploy)
 1. [Setup](#setup)

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ docker run -d -p 27017:27017 --name mongo-chatui mongo:latest
 
 In which case the url of your DB will be `MONGODB_URL=mongodb://localhost:27017`.
 
-Alternatively, you can use a [free MongoDB Atlas](https://www.mongodb.com/pricing) instance for this, Chat UI should fit comfortably within the free tier. After which you can set the `MONGODB_URL` variable in `.env.local` to match your instance.
+Alternatively, you can use a [free MongoDB Atlas](https://www.mongodb.com/pricing) instance for this, Chat UI should fit comfortably within their free tier. After which you can set the `MONGODB_URL` variable in `.env.local` to match your instance.
 
 ### Hugging Face Access Token
 
-You will need a Hugging Face access token to run Chat UI locally, using the remote inference endpoints. You can get one from [your Hugging Face profile](https://huggingface.co/settings/tokens).
+You will need a Hugging Face access token to run Chat UI locally, if you use a remote inference endpoint. You can get one from [your Hugging Face profile](https://huggingface.co/settings/tokens).
 
 ## Launch
 
@@ -152,7 +152,11 @@ You can change things like the parameters, or customize the preprompt to better 
 
 #### Running your own models using a custom endpoint
 
-If you want to, you can even run your own models locally, by having a look at our endpoint project, [text-generation-inference](https://github.com/huggingface/text-generation-inference). You can then add your own endpoints to the `MODELS` variable in `.env.local`, by adding an `"endpoints"` key for each model in `MODELS`.
+If you want to, instead of hitting models on the Hugging Face Inference API, you can run your own models locally.
+
+A good option is to hit a [text-generation-inference](https://github.com/huggingface/text-generation-inference) endpoint. This is what is done in the official [Chat UI Spaces Docker template](https://huggingface.co/new-space?template=huggingchat/chat-ui-template) for instance: both this app and a text-generation-inference server run inside the same container.
+
+To do this, you can add your own endpoints to the `MODELS` variable in `.env.local`, by adding an `"endpoints"` key for each model in `MODELS`.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A chat interface using open source models, eg OpenAssistant. It is a SvelteKit a
 If you don't want to configure, setup, and launch your own Chat UI yourself, you can use this option as a fast deploy alternative.
 
 You can deploy your own customized Chat UI instance with any supported LLM of your choice with only a few clicks to Hugging Face Spaces thanks to the Chat UI Spaces Docker template. Get started [here](https://huggingface.co/new-space?template=huggingchat/chat-ui-template).
+If you'd like to deploy a model with gated access or a model in a private repository, you can simply provide `HUGGING_FACE_HUB_TOKEN` in [Space secrets](https://huggingface.co/docs/hub/spaces-overview#managing-secrets-and-environment-variables). You need to set its value to an access token you can get from [here](https://huggingface.co/settings/tokens).
 
 Read the full tutorial [here](https://huggingface.co/docs/hub/spaces-sdks-docker-chatui#chatui-on-spaces).
 

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -13,18 +13,19 @@ export async function buildPrompt(
 	model: BackendModel,
 	webSearchId?: string
 ): Promise<string> {
+	const userEndToken = model.userMessageEndToken ?? model.messageEndToken;
+	const assistantEndToken = model.assistantMessageEndToken ?? model.messageEndToken;
+
 	const prompt =
 		messages
-			.map(
-				(m) =>
-					(m.from === "user"
-						? model.userMessageToken + m.content
-						: model.assistantMessageToken + m.content) +
-					(model.messageEndToken
-						? m.content.endsWith(model.messageEndToken)
-							? ""
-							: model.messageEndToken
-						: "")
+			.map((m) =>
+				m.from === "user"
+					? model.userMessageToken +
+					  m.content +
+					  (m.content.endsWith(userEndToken) ? "" : userEndToken)
+					: model.assistantMessageToken +
+					  m.content +
+					  (m.content.endsWith(assistantEndToken) ? "" : assistantEndToken)
 			)
 			.join("") + model.assistantMessageToken;
 
@@ -41,7 +42,7 @@ export async function buildPrompt(
 			webPrompt =
 				model.assistantMessageToken +
 				`The following context was found while searching the internet: ${webSearch.summary}` +
-				model.messageEndToken;
+				model.assistantMessageEndToken;
 		}
 	}
 	const finalPrompt =

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -18,7 +18,11 @@
 		id: string;
 		title: string;
 	}> = [];
+
+	export let canLogin: boolean;
 	export let user: LayoutData["user"];
+
+	export let loginModalVisible;
 </script>
 
 <div class="sticky top-0 flex flex-none items-center justify-between px-3 py-3.5 max-sm:pt-0">
@@ -60,6 +64,15 @@
 				Sign Out
 			</button>
 		</form>
+	{/if}
+	{#if canLogin}
+		<button
+			on:click={() => (loginModalVisible = true)}
+			type="button"
+			class="flex h-9 flex-none items-center gap-1.5 rounded-lg pl-3 pr-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+		>
+			Login
+		</button>
 	{/if}
 	<button
 		on:click={switchTheme}

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -53,12 +53,19 @@
 					You can change this setting at any time, it applies to all your conversations.
 				</p>
 				<p class="text-gray-800">
-					Read more about this model's authors,
+					Read more about model authors,
 					<a
 						href="https://open-assistant.io/"
 						target="_blank"
 						rel="noreferrer"
 						class="underline decoration-gray-300 hover:decoration-gray-700">Open Assistant</a
+					>
+					or
+					<a
+						href="https://ai.meta.com/llama/"
+						target="_blank"
+						rel="noreferrer"
+						class="underline decoration-gray-300 hover:decoration-gray-700">Meta AI</a
 					>.
 				</p>
 			{/if}

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -8,8 +8,10 @@
 	import { enhance } from "$app/forms";
 	import { base } from "$app/paths";
 	import { PUBLIC_APP_DATA_SHARING } from "$env/static/public";
+	import type { Model } from "$lib/types/Model";
 
 	export let settings: Pick<Settings, "shareConversationsWithModelAuthors">;
+	export let models: Array<Model>;
 
 	let shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
 	let isConfirmingDeletion = false;
@@ -52,22 +54,21 @@
 				<p class="text-gray-800">
 					You can change this setting at any time, it applies to all your conversations.
 				</p>
-				<p class="text-gray-800">
-					Read more about model authors,
-					<a
-						href="https://open-assistant.io/"
-						target="_blank"
-						rel="noreferrer"
-						class="underline decoration-gray-300 hover:decoration-gray-700">Open Assistant</a
-					>
-					or
-					<a
-						href="https://ai.meta.com/llama/"
-						target="_blank"
-						rel="noreferrer"
-						class="underline decoration-gray-300 hover:decoration-gray-700">Meta AI</a
-					>.
-				</p>
+				<div>
+					<p class="text-gray-800 ">Read more about model authors:</p>
+					<ul class="list-inside list-disc">
+						{#each models as model}
+							<li class="list-item">
+								<a
+									href={model["websiteUrl"]}
+									target="_blank"
+									rel="noreferrer"
+									class="underline decoration-gray-300 hover:decoration-gray-700">{model["name"]}</a
+								>
+							</li>
+						{/each}
+					</ul>
+				</div>
 			{/if}
 			<form
 				method="post"

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -124,7 +124,7 @@
 		<div class="mt-2 flex justify-between self-stretch px-1 text-xs text-gray-400/90 max-sm:gap-2">
 			<p>
 				Model: <a
-					href="https://huggingface.co/{currentModel.name}"
+					href={currentModel.modelUrl || "https://huggingface.co/" + currentModel.name}
 					target="_blank"
 					rel="noreferrer"
 					class="hover:underline">{currentModel.displayName}</a

--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -37,7 +37,16 @@ export async function generateFromDefaultEndpoint(
 		}
 	);
 
-	generated_text = trimSuffix(trimPrefix(generated_text, "<|startoftext|>"), PUBLIC_SEP_TOKEN);
+	generated_text = trimSuffix(
+		trimPrefix(generated_text, "<|startoftext|>"),
+		PUBLIC_SEP_TOKEN
+	).trimEnd();
+
+	for (const stop of [...(newParameters?.stop ?? []), "<|endoftext|>"]) {
+		if (generated_text.endsWith(stop)) {
+			generated_text = generated_text.slice(0, -stop.length).trimEnd();
+		}
+	}
 
 	return generated_text;
 }

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -14,9 +14,11 @@ const modelsRaw = z
 			modelUrl: z.string().url().optional(),
 			datasetName: z.string().min(1).optional(),
 			datasetUrl: z.string().url().optional(),
-			userMessageToken: z.string().min(1),
-			assistantMessageToken: z.string().min(1),
-			messageEndToken: z.string().min(1).optional(),
+			userMessageToken: z.string(),
+			userMessageEndToken: z.string().default(""),
+			assistantMessageToken: z.string(),
+			assistantMessageEndToken: z.string().default(""),
+			messageEndToken: z.string().default(""),
 			preprompt: z.string().default(""),
 			prepromptUrl: z.string().url().optional(),
 			promptExamples: z
@@ -52,6 +54,8 @@ const modelsRaw = z
 export const models = await Promise.all(
 	modelsRaw.map(async (m) => ({
 		...m,
+		userMessageEndToken: m?.userMessageEndToken || m?.messageEndToken,
+		assistantMessageEndToken: m?.assistantMessageEndToken || m?.messageEndToken,
 		id: m.id || m.name,
 		displayName: m.displayName || m.name,
 		preprompt: m.prepromptUrl ? await fetch(m.prepromptUrl).then((r) => r.text()) : m.preprompt,

--- a/src/lib/server/websearch/generateQuery.ts
+++ b/src/lib/server/websearch/generateQuery.ts
@@ -6,13 +6,13 @@ export async function generateQuery(messages: Message[], model: BackendModel) {
 	const promptSearchQuery =
 		model.userMessageToken +
 		"The following messages were written by a user, trying to answer a question." +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		messages
 			.filter((message) => message.from === "user")
-			.map((message) => model.userMessageToken + message.content + model.messageEndToken) +
+			.map((message) => model.userMessageToken + message.content + model.userMessageEndToken) +
 		model.userMessageToken +
 		"What plain-text english sentence would you input into Google to answer the last question? Answer with a short (10 words max) simple sentence." +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		model.assistantMessageToken +
 		"Query: ";
 

--- a/src/lib/server/websearch/summarizeWeb.ts
+++ b/src/lib/server/websearch/summarizeWeb.ts
@@ -29,10 +29,10 @@ export async function summarizeWeb(content: string, query: string, model: Backen
 			.split(" ")
 			.slice(0, model.parameters?.truncate ?? 0)
 			.join(" ") +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		model.userMessageToken +
 		`The text above should be summarized to best answer the query: ${query}.` +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		model.assistantMessageToken +
 		"Summary: ";
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -176,7 +176,11 @@
 		<Toast message={currentError} />
 	{/if}
 	{#if isSettingsOpen}
-		<SettingsModal on:close={() => (isSettingsOpen = false)} settings={data.settings} />
+		<SettingsModal
+			on:close={() => (isSettingsOpen = false)}
+			settings={data.settings}
+			models={data.models}
+		/>
 	{/if}
 	{#if requiresLogin && data.messagesBeforeLogin === 0}
 		<LoginModal settings={data.settings} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -99,6 +99,8 @@
 		(data.requiresLogin
 			? !data.user
 			: !data.settings.ethicsModalAcceptedAt && !!PUBLIC_APP_DISCLAIMER);
+
+	let loginModalVisible = false;
 </script>
 
 <svelte:head>
@@ -156,6 +158,8 @@
 		<NavMenu
 			conversations={data.conversations}
 			user={data.user}
+			canLogin={data.user === undefined && data.requiresLogin}
+			bind:loginModalVisible
 			on:shareConversation={(ev) => shareConversation(ev.detail.id, ev.detail.title)}
 			on:deleteConversation={(ev) => deleteConversation(ev.detail)}
 			on:clickSettings={() => (isSettingsOpen = true)}
@@ -166,6 +170,8 @@
 		<NavMenu
 			conversations={data.conversations}
 			user={data.user}
+			canLogin={data.user === undefined && data.requiresLogin}
+			bind:loginModalVisible
 			on:shareConversation={(ev) => shareConversation(ev.detail.id, ev.detail.title)}
 			on:deleteConversation={(ev) => deleteConversation(ev.detail)}
 			on:clickSettings={() => (isSettingsOpen = true)}
@@ -182,7 +188,7 @@
 			models={data.models}
 		/>
 	{/if}
-	{#if requiresLogin && data.messagesBeforeLogin === 0}
+	{#if (requiresLogin && data.messagesBeforeLogin === 0) || loginModalVisible}
 		<LoginModal settings={data.settings} />
 	{/if}
 	<slot />


### PR DESCRIPTION
Hi @EsoCoding,

Notice you forked chat-ui. if you're trying to test other LLMs (codellama, wizardcoder, etc.) with it, I just wrote a [1-click proxy](https://github.com/BerriAI/litellm#openai-proxy-server) to translate openai calls to huggingface, anthropic, togetherai, etc. api calls.

**code**
```
$ pip install litellm

$ litellm --model huggingface/bigcode/starcoder

#INFO:     Uvicorn running on http://0.0.0.0:8000

>> openai.api_base = "http://0.0.0.0:8000"
```

Here's the PR on adding openai to chat-ui: https://github.com/huggingface/chat-ui/pull/452

I'd love to know if this solves a problem for you